### PR TITLE
The Paste option is missing when using the Right Click Context Menu in the centerPanelGrid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.vscode/launch.json
+.vscode/tasks.json
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -406,6 +406,3 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
-.vscode/launch.json
-.vscode/tasks.json
-.gitignore

--- a/cp2_wpf/MainWindow.xaml
+++ b/cp2_wpf/MainWindow.xaml
@@ -692,6 +692,7 @@ limitations under the License.
                                 <MenuItem Command="{StaticResource ExtractFilesCmd}"/>
                                 <MenuItem Command="{StaticResource ExportFilesCmd}"/>
                                 <MenuItem Command="Copy"/>
+                                <MenuItem Command="Paste"/>
                                 <MenuItem Command="{StaticResource DeleteFilesCmd}"/>
                                 <MenuItem Command="{StaticResource TestFilesCmd}"/>
                                 <Separator/>


### PR DESCRIPTION
I kept trying to right-click to Paste files from one disk to another.  This commit adds the Paste command to the ContextMenu when the user right clicks in the centerPanelGrid
![Screenshot 2024-01-25 200450](https://github.com/fadden/CiderPress2/assets/19356109/ef47973a-dbbe-488e-babe-901ed4c3affe)
