### PR TITLE
Add code for processing and converting Print Shop fonts

### DIFF
--- a/FileConv/ExportFoundry.cs
+++ b/FileConv/ExportFoundry.cs
@@ -25,11 +25,13 @@ using DiskArc.FS;
 using static DiskArc.Defs;
 using static DiskArc.IFileSystem;
 
-namespace FileConv {
+namespace FileConv
+{
     /// <summary>
     /// Export converter class instance creator.
     /// </summary>
-    public static class ExportFoundry {
+    public static class ExportFoundry
+    {
         /// <summary>
         /// List of supported export converters.
         /// </summary>
@@ -74,20 +76,24 @@ namespace FileConv {
             new ConverterEntry(typeof(Gfx.SuperHiRes_Packed)),
             new ConverterEntry(typeof(Gfx.SuperHiRes_Paintworks)),
             new ConverterEntry(typeof(Gfx.PrintShopClip)),
+            new ConverterEntry(typeof(Gfx.PrintShopFont)),
             new ConverterEntry(typeof(Gfx.HostImage)),
             new ConverterEntry(typeof(Gfx.MacPaint)),
         };
 
         private static readonly Dictionary<string, ConverterEntry> sTagList = GenerateTagList();
-        private static Dictionary<string, ConverterEntry> GenerateTagList() {
+        private static Dictionary<string, ConverterEntry> GenerateTagList()
+        {
             Dictionary<string, ConverterEntry> newList = new Dictionary<string, ConverterEntry>();
-            foreach (ConverterEntry entry in sConverters) {
+            foreach (ConverterEntry entry in sConverters)
+            {
                 newList.Add(entry.Tag, entry);
             }
             return newList;
         }
 
-        private class ConverterEntry {
+        private class ConverterEntry
+        {
             // Tag from class TAG constant.
             public string Tag { get; private set; }
             public string Label { get; private set; }
@@ -101,7 +107,8 @@ namespace FileConv {
             // Cached reflection reference to constructor.
             private ConstructorInfo mCtorInfo;
 
-            public ConverterEntry(Type implClass) {
+            public ConverterEntry(Type implClass)
+            {
                 Debug.Assert(implClass.IsSubclassOf(typeof(Converter)));
 
                 mImplClass = implClass;
@@ -112,7 +119,8 @@ namespace FileConv {
 
                 ConstructorInfo? nullCtor = implClass.GetConstructor(
                     BindingFlags.NonPublic | BindingFlags.Instance, Array.Empty<Type>());
-                if (nullCtor == null) {
+                if (nullCtor == null)
+                {
                     throw new Exception("Unable to find nullary ctor in " + implClass.FullName);
                 }
                 object instance = nullCtor.Invoke(Array.Empty<object>());
@@ -130,7 +138,8 @@ namespace FileConv {
                         typeof(Stream), typeof(ResourceMgr), typeof(Converter.ConvFlags),
                         typeof(AppHook) }
                     );
-                if (ctor == null) {
+                if (ctor == null)
+                {
                     throw new Exception("Unable to find ctor in " + implClass.FullName);
                 }
                 mCtorInfo = ctor;
@@ -147,18 +156,25 @@ namespace FileConv {
             /// <returns>New instance.</returns>
             public Converter CreateInstance(FileAttribs attrs, Stream? dataStream,
                     Stream? rsrcStream, ResourceMgr? resMgr, Converter.ConvFlags convFlags,
-                    AppHook appHook) {
+                    AppHook appHook)
+            {
                 object instance;
-                try {
+                try
+                {
                     instance = mCtorInfo.Invoke(new object?[] {
-                        attrs, dataStream, rsrcStream, resMgr, convFlags, appHook } );
-                } catch (TargetInvocationException ex) {
-                    if (ex.InnerException != null) {
+                        attrs, dataStream, rsrcStream, resMgr, convFlags, appHook });
+                }
+                catch (TargetInvocationException ex)
+                {
+                    if (ex.InnerException != null)
+                    {
                         // Re-throwing an inner exception loses the stack trace.  Do this instead.
                         ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
                         // This is not reached, but the compiler doesn't know that.
                         throw ex.InnerException;
-                    } else {
+                    }
+                    else
+                    {
                         throw;
                     }
                 }
@@ -169,7 +185,8 @@ namespace FileConv {
         /// <summary>
         /// Returns a sorted list of export converter tags.
         /// </summary>
-        public static List<string> GetConverterTags() {
+        public static List<string> GetConverterTags()
+        {
             List<string> keys = sTagList.Keys.ToList();
             keys.Sort();
             return keys;
@@ -178,7 +195,8 @@ namespace FileConv {
         /// <summary>
         /// Returns the number of known export converters.
         /// </summary>
-        public static int GetCount() {
+        public static int GetCount()
+        {
             return sConverters.Length;
         }
 
@@ -190,7 +208,8 @@ namespace FileConv {
         /// <param name="label">Result: UI label.</param>
         /// <param name="description">Result: long description.</param>
         public static void GetConverterInfo(int index, out string tag, out string label,
-                out string description, out List<Converter.OptionDefinition> optionDefs) {
+                out string description, out List<Converter.OptionDefinition> optionDefs)
+        {
             ConverterEntry entry = sConverters[index];
             tag = entry.Tag;
             label = entry.Label;
@@ -207,17 +226,20 @@ namespace FileConv {
         /// <param name="rsrcStream">Rsrc fork stream; may be null.</param>
         /// <returns>New instance, or null if the tag couldn't be found.</returns>
         public static Converter? GetConverter(string tag, FileAttribs attrs, Stream? dataStream,
-                Stream? rsrcStream, AppHook appHook) {
+                Stream? rsrcStream, AppHook appHook)
+        {
             Debug.Assert(dataStream == null || dataStream.CanSeek);
             Debug.Assert(rsrcStream == null || rsrcStream.CanSeek);
 
-            if (!sTagList.TryGetValue(tag, out ConverterEntry? convEntry)) {
+            if (!sTagList.TryGetValue(tag, out ConverterEntry? convEntry))
+            {
                 Debug.WriteLine("Converter tag '" + tag + "' not found");
                 return null;
             }
 
             ResourceMgr? resMgr = null;
-            if (rsrcStream != null && rsrcStream.Length > 0) {
+            if (rsrcStream != null && rsrcStream.Length > 0)
+            {
                 resMgr = ResourceMgr.Create(rsrcStream);
             }
             bool isRawDOS = (dataStream is DOS_FileDesc &&
@@ -249,25 +271,34 @@ namespace FileConv {
         /// <exception cref="IOException">Error occurred while opening files.</exception>
         public static List<Converter> GetApplicableConverters(object archiveOrFileSystem,
                 IFileEntry fileEntry, FileAttribs attrs, bool useRawMode, bool enableMacZip,
-                out Stream? dataStream, out Stream? rsrcStream, AppHook appHook) {
+                out Stream? dataStream, out Stream? rsrcStream, AppHook appHook)
+        {
             // Create streams for data and resource forks.
             dataStream = null;
             rsrcStream = null;
 
-            if (archiveOrFileSystem is IArchive) {
+            if (archiveOrFileSystem is IArchive)
+            {
                 IArchive arc = (IArchive)archiveOrFileSystem;
-                if (fileEntry.IsDiskImage) {
+                if (fileEntry.IsDiskImage)
+                {
                     // Normally we shouldn't be here, but this could happen if the main app
                     // couldn't recognize the disk image and kicked it over for a hex dump.
                     dataStream = ExtractToTemp(arc, fileEntry, FilePart.DiskImage);
-                } else if (fileEntry.HasDataFork) {
+                }
+                else if (fileEntry.HasDataFork)
+                {
                     dataStream = ExtractToTemp(arc, fileEntry, FilePart.DataFork);
                 }
-                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0) {
+                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0)
+                {
                     rsrcStream = ExtractToTemp(arc, fileEntry, FilePart.RsrcFork);
-                } else if (enableMacZip && arc is Zip &&
-                        Zip.HasMacZipHeader(arc, fileEntry, out IFileEntry adfEntry)) {
-                    try {
+                }
+                else if (enableMacZip && arc is Zip &&
+                        Zip.HasMacZipHeader(arc, fileEntry, out IFileEntry adfEntry))
+                {
+                    try
+                    {
                         // Open the AppleDouble header.
                         using ArcReadStream entryStream = arc.OpenPart(adfEntry, FilePart.DataFork);
                         Stream adfStream = TempFile.CopyToTemp(entryStream, adfEntry.DataLength);
@@ -275,22 +306,29 @@ namespace FileConv {
                         IFileEntry adfArcEntry = adfArc.GetFirstEntry();
                         // Get file attributes.  If it has a resource fork, extract that.
                         attrs.GetFromAppleSingle(adfArcEntry);
-                        if (adfArcEntry.HasRsrcFork && adfArcEntry.RsrcLength > 0) {
+                        if (adfArcEntry.HasRsrcFork && adfArcEntry.RsrcLength > 0)
+                        {
                             rsrcStream = ExtractToTemp(adfArc, adfArcEntry, FilePart.RsrcFork);
                         }
-                    } catch (Exception ex) {
+                    }
+                    catch (Exception ex)
+                    {
                         // Never mind.
                         Debug.WriteLine("Failed opening ADF header: " + ex.Message);
                         Debug.Assert(rsrcStream == null);
                     }
                 }
-            } else {
+            }
+            else
+            {
                 IFileSystem fs = (IFileSystem)archiveOrFileSystem;
-                if (fileEntry.HasDataFork) {
+                if (fileEntry.HasDataFork)
+                {
                     FilePart part = useRawMode ? FilePart.RawData : FilePart.DataFork;
                     dataStream = fs.OpenFile(fileEntry, FileAccessMode.ReadOnly, part);
                 }
-                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0) {
+                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0)
+                {
                     rsrcStream = fs.OpenFile(fileEntry, FileAccessMode.ReadOnly, FilePart.RsrcFork);
                 }
             }
@@ -308,14 +346,16 @@ namespace FileConv {
         /// <param name="appHook">Application hook reference.</param>
         /// <returns>List of applicable converter objects.</returns>
         public static List<Converter> GetApplicableConverters(FileAttribs attrs,
-                Stream? dataStream, Stream? rsrcStream, AppHook appHook) {
+                Stream? dataStream, Stream? rsrcStream, AppHook appHook)
+        {
             Debug.Assert(dataStream == null || dataStream.CanSeek);
             Debug.Assert(rsrcStream == null || rsrcStream.CanSeek);
 
             List<Converter> converters = new List<Converter>();
 
             ResourceMgr? resMgr = null;
-            if (rsrcStream != null && rsrcStream.Length > 0) {
+            if (rsrcStream != null && rsrcStream.Length > 0)
+            {
                 resMgr = ResourceMgr.Create(rsrcStream);
             }
             bool isRawDOS = (dataStream is DOS_FileDesc &&
@@ -323,23 +363,31 @@ namespace FileConv {
             Converter.ConvFlags convFlags =
                 isRawDOS ? Converter.ConvFlags.IsRawDOS : Converter.ConvFlags.None;
 
-            foreach (ConverterEntry conv in sConverters) {
+            foreach (ConverterEntry conv in sConverters)
+            {
                 Converter instance =
                     conv.CreateInstance(attrs, dataStream, rsrcStream, resMgr, convFlags, appHook);
                 Converter.Applicability applic = instance.Applic;
 
-                if (applic > Converter.Applicability.Not) {
+                if (applic > Converter.Applicability.Not)
+                {
                     converters.Add(instance);
                 }
             }
 
             // Sort results based on applicability.
-            converters.Sort(delegate (Converter ent1, Converter ent2) {
-                if (ent1.Applic > ent2.Applic) {
+            converters.Sort(delegate (Converter ent1, Converter ent2)
+            {
+                if (ent1.Applic > ent2.Applic)
+                {
                     return -1;
-                } else if (ent1.Applic < ent2.Applic) {
+                }
+                else if (ent1.Applic < ent2.Applic)
+                {
                     return 1;
-                } else {
+                }
+                else
+                {
                     return 0;
                 }
             });
@@ -357,7 +405,8 @@ namespace FileConv {
         /// <param name="entry">Entry to extract.</param>
         /// <param name="part">File part to extract.</param>
         /// <returns>Temporary stream.</returns>
-        private static Stream ExtractToTemp(IArchive archive, IFileEntry entry, FilePart part) {
+        private static Stream ExtractToTemp(IArchive archive, IFileEntry entry, FilePart part)
+        {
             using ArcReadStream entryStream = archive.OpenPart(entry, part);
 
             // Get the length of the part we're extracting.  For gzip we need to do the part

--- a/FileConv/ExportFoundry.cs
+++ b/FileConv/ExportFoundry.cs
@@ -25,13 +25,11 @@ using DiskArc.FS;
 using static DiskArc.Defs;
 using static DiskArc.IFileSystem;
 
-namespace FileConv
-{
+namespace FileConv {
     /// <summary>
     /// Export converter class instance creator.
     /// </summary>
-    public static class ExportFoundry
-    {
+    public static class ExportFoundry {
         /// <summary>
         /// List of supported export converters.
         /// </summary>
@@ -82,18 +80,15 @@ namespace FileConv
         };
 
         private static readonly Dictionary<string, ConverterEntry> sTagList = GenerateTagList();
-        private static Dictionary<string, ConverterEntry> GenerateTagList()
-        {
+        private static Dictionary<string, ConverterEntry> GenerateTagList() {
             Dictionary<string, ConverterEntry> newList = new Dictionary<string, ConverterEntry>();
-            foreach (ConverterEntry entry in sConverters)
-            {
+            foreach (ConverterEntry entry in sConverters) {
                 newList.Add(entry.Tag, entry);
             }
             return newList;
         }
 
-        private class ConverterEntry
-        {
+        private class ConverterEntry {
             // Tag from class TAG constant.
             public string Tag { get; private set; }
             public string Label { get; private set; }
@@ -107,8 +102,7 @@ namespace FileConv
             // Cached reflection reference to constructor.
             private ConstructorInfo mCtorInfo;
 
-            public ConverterEntry(Type implClass)
-            {
+            public ConverterEntry(Type implClass) {
                 Debug.Assert(implClass.IsSubclassOf(typeof(Converter)));
 
                 mImplClass = implClass;
@@ -119,8 +113,7 @@ namespace FileConv
 
                 ConstructorInfo? nullCtor = implClass.GetConstructor(
                     BindingFlags.NonPublic | BindingFlags.Instance, Array.Empty<Type>());
-                if (nullCtor == null)
-                {
+                if (nullCtor == null) {
                     throw new Exception("Unable to find nullary ctor in " + implClass.FullName);
                 }
                 object instance = nullCtor.Invoke(Array.Empty<object>());
@@ -138,8 +131,7 @@ namespace FileConv
                         typeof(Stream), typeof(ResourceMgr), typeof(Converter.ConvFlags),
                         typeof(AppHook) }
                     );
-                if (ctor == null)
-                {
+                if (ctor == null) {
                     throw new Exception("Unable to find ctor in " + implClass.FullName);
                 }
                 mCtorInfo = ctor;
@@ -156,25 +148,18 @@ namespace FileConv
             /// <returns>New instance.</returns>
             public Converter CreateInstance(FileAttribs attrs, Stream? dataStream,
                     Stream? rsrcStream, ResourceMgr? resMgr, Converter.ConvFlags convFlags,
-                    AppHook appHook)
-            {
+                    AppHook appHook) {
                 object instance;
-                try
-                {
+                try {
                     instance = mCtorInfo.Invoke(new object?[] {
-                        attrs, dataStream, rsrcStream, resMgr, convFlags, appHook });
-                }
-                catch (TargetInvocationException ex)
-                {
-                    if (ex.InnerException != null)
-                    {
+                        attrs, dataStream, rsrcStream, resMgr, convFlags, appHook } );
+                } catch (TargetInvocationException ex) {
+                    if (ex.InnerException != null) {
                         // Re-throwing an inner exception loses the stack trace.  Do this instead.
                         ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
                         // This is not reached, but the compiler doesn't know that.
                         throw ex.InnerException;
-                    }
-                    else
-                    {
+                    } else {
                         throw;
                     }
                 }
@@ -185,8 +170,7 @@ namespace FileConv
         /// <summary>
         /// Returns a sorted list of export converter tags.
         /// </summary>
-        public static List<string> GetConverterTags()
-        {
+        public static List<string> GetConverterTags() {
             List<string> keys = sTagList.Keys.ToList();
             keys.Sort();
             return keys;
@@ -195,8 +179,7 @@ namespace FileConv
         /// <summary>
         /// Returns the number of known export converters.
         /// </summary>
-        public static int GetCount()
-        {
+        public static int GetCount() {
             return sConverters.Length;
         }
 
@@ -208,8 +191,7 @@ namespace FileConv
         /// <param name="label">Result: UI label.</param>
         /// <param name="description">Result: long description.</param>
         public static void GetConverterInfo(int index, out string tag, out string label,
-                out string description, out List<Converter.OptionDefinition> optionDefs)
-        {
+                out string description, out List<Converter.OptionDefinition> optionDefs) {
             ConverterEntry entry = sConverters[index];
             tag = entry.Tag;
             label = entry.Label;
@@ -226,20 +208,17 @@ namespace FileConv
         /// <param name="rsrcStream">Rsrc fork stream; may be null.</param>
         /// <returns>New instance, or null if the tag couldn't be found.</returns>
         public static Converter? GetConverter(string tag, FileAttribs attrs, Stream? dataStream,
-                Stream? rsrcStream, AppHook appHook)
-        {
+                Stream? rsrcStream, AppHook appHook) {
             Debug.Assert(dataStream == null || dataStream.CanSeek);
             Debug.Assert(rsrcStream == null || rsrcStream.CanSeek);
 
-            if (!sTagList.TryGetValue(tag, out ConverterEntry? convEntry))
-            {
+            if (!sTagList.TryGetValue(tag, out ConverterEntry? convEntry)) {
                 Debug.WriteLine("Converter tag '" + tag + "' not found");
                 return null;
             }
 
             ResourceMgr? resMgr = null;
-            if (rsrcStream != null && rsrcStream.Length > 0)
-            {
+            if (rsrcStream != null && rsrcStream.Length > 0) {
                 resMgr = ResourceMgr.Create(rsrcStream);
             }
             bool isRawDOS = (dataStream is DOS_FileDesc &&
@@ -271,34 +250,25 @@ namespace FileConv
         /// <exception cref="IOException">Error occurred while opening files.</exception>
         public static List<Converter> GetApplicableConverters(object archiveOrFileSystem,
                 IFileEntry fileEntry, FileAttribs attrs, bool useRawMode, bool enableMacZip,
-                out Stream? dataStream, out Stream? rsrcStream, AppHook appHook)
-        {
+                out Stream? dataStream, out Stream? rsrcStream, AppHook appHook) {
             // Create streams for data and resource forks.
             dataStream = null;
             rsrcStream = null;
 
-            if (archiveOrFileSystem is IArchive)
-            {
+            if (archiveOrFileSystem is IArchive) {
                 IArchive arc = (IArchive)archiveOrFileSystem;
-                if (fileEntry.IsDiskImage)
-                {
+                if (fileEntry.IsDiskImage) {
                     // Normally we shouldn't be here, but this could happen if the main app
                     // couldn't recognize the disk image and kicked it over for a hex dump.
                     dataStream = ExtractToTemp(arc, fileEntry, FilePart.DiskImage);
-                }
-                else if (fileEntry.HasDataFork)
-                {
+                } else if (fileEntry.HasDataFork) {
                     dataStream = ExtractToTemp(arc, fileEntry, FilePart.DataFork);
                 }
-                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0)
-                {
+                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0) {
                     rsrcStream = ExtractToTemp(arc, fileEntry, FilePart.RsrcFork);
-                }
-                else if (enableMacZip && arc is Zip &&
-                        Zip.HasMacZipHeader(arc, fileEntry, out IFileEntry adfEntry))
-                {
-                    try
-                    {
+                } else if (enableMacZip && arc is Zip &&
+                        Zip.HasMacZipHeader(arc, fileEntry, out IFileEntry adfEntry)) {
+                    try {
                         // Open the AppleDouble header.
                         using ArcReadStream entryStream = arc.OpenPart(adfEntry, FilePart.DataFork);
                         Stream adfStream = TempFile.CopyToTemp(entryStream, adfEntry.DataLength);
@@ -306,29 +276,22 @@ namespace FileConv
                         IFileEntry adfArcEntry = adfArc.GetFirstEntry();
                         // Get file attributes.  If it has a resource fork, extract that.
                         attrs.GetFromAppleSingle(adfArcEntry);
-                        if (adfArcEntry.HasRsrcFork && adfArcEntry.RsrcLength > 0)
-                        {
+                        if (adfArcEntry.HasRsrcFork && adfArcEntry.RsrcLength > 0) {
                             rsrcStream = ExtractToTemp(adfArc, adfArcEntry, FilePart.RsrcFork);
                         }
-                    }
-                    catch (Exception ex)
-                    {
+                    } catch (Exception ex) {
                         // Never mind.
                         Debug.WriteLine("Failed opening ADF header: " + ex.Message);
                         Debug.Assert(rsrcStream == null);
                     }
                 }
-            }
-            else
-            {
+            } else {
                 IFileSystem fs = (IFileSystem)archiveOrFileSystem;
-                if (fileEntry.HasDataFork)
-                {
+                if (fileEntry.HasDataFork) {
                     FilePart part = useRawMode ? FilePart.RawData : FilePart.DataFork;
                     dataStream = fs.OpenFile(fileEntry, FileAccessMode.ReadOnly, part);
                 }
-                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0)
-                {
+                if (fileEntry.HasRsrcFork && fileEntry.RsrcLength > 0) {
                     rsrcStream = fs.OpenFile(fileEntry, FileAccessMode.ReadOnly, FilePart.RsrcFork);
                 }
             }
@@ -346,16 +309,14 @@ namespace FileConv
         /// <param name="appHook">Application hook reference.</param>
         /// <returns>List of applicable converter objects.</returns>
         public static List<Converter> GetApplicableConverters(FileAttribs attrs,
-                Stream? dataStream, Stream? rsrcStream, AppHook appHook)
-        {
+                Stream? dataStream, Stream? rsrcStream, AppHook appHook) {
             Debug.Assert(dataStream == null || dataStream.CanSeek);
             Debug.Assert(rsrcStream == null || rsrcStream.CanSeek);
 
             List<Converter> converters = new List<Converter>();
 
             ResourceMgr? resMgr = null;
-            if (rsrcStream != null && rsrcStream.Length > 0)
-            {
+            if (rsrcStream != null && rsrcStream.Length > 0) {
                 resMgr = ResourceMgr.Create(rsrcStream);
             }
             bool isRawDOS = (dataStream is DOS_FileDesc &&
@@ -363,31 +324,23 @@ namespace FileConv
             Converter.ConvFlags convFlags =
                 isRawDOS ? Converter.ConvFlags.IsRawDOS : Converter.ConvFlags.None;
 
-            foreach (ConverterEntry conv in sConverters)
-            {
+            foreach (ConverterEntry conv in sConverters) {
                 Converter instance =
                     conv.CreateInstance(attrs, dataStream, rsrcStream, resMgr, convFlags, appHook);
                 Converter.Applicability applic = instance.Applic;
 
-                if (applic > Converter.Applicability.Not)
-                {
+                if (applic > Converter.Applicability.Not) {
                     converters.Add(instance);
                 }
             }
 
             // Sort results based on applicability.
-            converters.Sort(delegate (Converter ent1, Converter ent2)
-            {
-                if (ent1.Applic > ent2.Applic)
-                {
+            converters.Sort(delegate (Converter ent1, Converter ent2) {
+                if (ent1.Applic > ent2.Applic) {
                     return -1;
-                }
-                else if (ent1.Applic < ent2.Applic)
-                {
+                } else if (ent1.Applic < ent2.Applic) {
                     return 1;
-                }
-                else
-                {
+                } else {
                     return 0;
                 }
             });
@@ -405,8 +358,7 @@ namespace FileConv
         /// <param name="entry">Entry to extract.</param>
         /// <param name="part">File part to extract.</param>
         /// <returns>Temporary stream.</returns>
-        private static Stream ExtractToTemp(IArchive archive, IFileEntry entry, FilePart part)
-        {
+        private static Stream ExtractToTemp(IArchive archive, IFileEntry entry, FilePart part) {
             using ArcReadStream entryStream = archive.OpenPart(entry, part);
 
             // Get the length of the part we're extracting.  For gzip we need to do the part

--- a/FileConv/Gfx/PrintShop-notes.md
+++ b/FileConv/Gfx/PrintShop-notes.md
@@ -1,29 +1,32 @@
-# Print Shop Graphics #
+# Print Shop Graphics
 
 File types:
- - BIN / $4800/5800/6800/7800, length 572 or 576: Print Shop 88x52 Monochrome Clip Art
- - BIN / $4800/5800/6800/7800, length 144 or 148: Print Shop 12x12 Monochrome Border
- - $f8 / $c311: Print Shop GS ?x? Monochrome Pattern
- - $f8 / $c312: Print Shop GS ?x? Monochrome Border
- - $f8 / $c313: Print Shop GS 88x52 Monochrome Clip Art
- - $f8 / $c316: Print Shop GS Font
- - $f8 / $c321: Print Shop GS ?x? 8-Color Pattern
- - $f8 / $c322: Print Shop GS ?x? 8-Color Border
- - $f8 / $c323: Print Shop GS 88x52 8-color Clip Art
- - $f8 / $c324: Print Shop GS "Full Panel GC"
- - $f8 / $c325: Print Shop GS "Full Panel LH"
- - $f8 / $c328: Print Shop GS "Editor"
- - $f8 / $c329: Print Shop GS "Full Panel EV"
+
+- BIN / $4800/5800/6800/7800, length 572 or 576: Print Shop 88x52 Monochrome Clip Art
+- BIN / $4800/5800/6800/7800, length 144 or 148: Print Shop 12x12 Monochrome Border
+- BIN / $5FF4/6000: Print Shop Font
+- $f8 / $c311: Print Shop GS ?x? Monochrome Pattern
+- $f8 / $c312: Print Shop GS ?x? Monochrome Border
+- $f8 / $c313: Print Shop GS 88x52 Monochrome Clip Art
+- $f8 / $c316: Print Shop GS Font
+- $f8 / $c321: Print Shop GS ?x? 8-Color Pattern
+- $f8 / $c322: Print Shop GS ?x? 8-Color Border
+- $f8 / $c323: Print Shop GS 88x52 8-color Clip Art
+- $f8 / $c324: Print Shop GS "Full Panel GC"
+- $f8 / $c325: Print Shop GS "Full Panel LH"
+- $f8 / $c328: Print Shop GS "Editor"
+- $f8 / $c329: Print Shop GS "Full Panel EV"
 
 Primary references:
- - Reverse engineering
+
+- Reverse engineering
 
 The ProDOS files used a generic type, so no file type notes exist for these formats.
 
 The web site https://theprintshop.club/ provides an emulated version of the original Apple II
 program that can print to PDF.
 
-## Clip Art ##
+## Clip Art
 
 The original Print Shop uses 88x52 monochrome images.  When printed or displayed, these are
 doubled in width and tripled in height to form a 176x156 image.  Print Shop GS also supports
@@ -39,13 +42,42 @@ the cyan plane.
 The actual color palette, as determined by a screen grab from an emulator, is comprised of RGB
 primaries and purple/orange that are similar to the classic Apple II hi-res colors.
 
-Y M C | color  | red, green, blue
------ | ------ | ----------------
-0 0 0 | white  | 0xff, 0xff, 0xff
-0 0 1 | blue   | 0x00, 0x00, 0xff
-0 1 0 | red    | 0xff, 0x00, 0x00
-0 1 1 | purple | 0xcc, 0x00, 0xcc
-1 0 0 | yellow | 0xff, 0xff, 0x00
-1 0 1 | green  | 0x00, 0xff, 0x00
-1 1 0 | orange | 0xff, 0x66, 0x00
-1 1 1 | black  | 0x00, 0x00, 0x00
+| Y M C | color  | red, green, blue |
+| ----- | ------ | ---------------- |
+| 0 0 0 | white  | 0xff, 0xff, 0xff |
+| 0 0 1 | blue   | 0x00, 0x00, 0xff |
+| 0 1 0 | red    | 0xff, 0x00, 0x00 |
+| 0 1 1 | purple | 0xcc, 0x00, 0xcc |
+| 1 0 0 | yellow | 0xff, 0xff, 0x00 |
+| 1 0 1 | green  | 0x00, 0xff, 0x00 |
+| 1 1 0 | orange | 0xff, 0x66, 0x00 |
+| 1 1 1 | black  | 0x00, 0x00, 0x00 |
+
+## Fonts
+
+Each font contains 59 characters (0-58).
+
+In the Print SHop Companion (PSC) font editor, offsets 0 (space) and 32 (image) are not editable.
+
+In Print Shop[, offset 32 points to the current graphic selected, which
+is generally not contained in the font file itself.  However, since it is an arbitrary data pointer, it is
+conceivble that there could be self-contained data in the file.
+
+The Space character is at offset 0, and in all the examples I've seen, has a height of 0 pixels.
+The data is calculated in the PSC font editor based off of an average of all other character widths.
+
+$5FF4-$5FFF - Optional Print Shop Companion Font Header (From Font Editor)
+$6000-$603A - Character widths (in pixels).  High bit indicates "Edited" in PSC.  Should be stripped.
+$603B-$6075 - Character heights in rows.
+$6076-$60B0 - Low Bytes of character data pointers
+$60B1-$60EB - High Bytes of character data pointers
+$60EC-EOF   - Character data.
+
+To check for validity, we can iterate through all 59 characters (excepting 0 and 32) and check that:
+
+- The address pointers fall within the range of the data file.
+- Width and height values are "reasonable".  The PSC font editor limits character sizes to a max of 48x38 (152 bytes)
+
+If all are within range, then acceptability should be flagged as Yes, if the pointers are in range, but some characters are out of the expected sizes, then the accptability should be flagged as ProbablyYes
+
+Like the Print Shop graphic data, fonts are expanded 2x3 in usage.

--- a/FileConv/Gfx/PrintShop-notes.md
+++ b/FileConv/Gfx/PrintShop-notes.md
@@ -1,32 +1,29 @@
-# Print Shop Graphics
+# Print Shop Graphics #
 
 File types:
-
-- BIN / $4800/5800/6800/7800, length 572 or 576: Print Shop 88x52 Monochrome Clip Art
-- BIN / $4800/5800/6800/7800, length 144 or 148: Print Shop 12x12 Monochrome Border
-- BIN / $5FF4/6000: Print Shop Font
-- $f8 / $c311: Print Shop GS ?x? Monochrome Pattern
-- $f8 / $c312: Print Shop GS ?x? Monochrome Border
-- $f8 / $c313: Print Shop GS 88x52 Monochrome Clip Art
-- $f8 / $c316: Print Shop GS Font
-- $f8 / $c321: Print Shop GS ?x? 8-Color Pattern
-- $f8 / $c322: Print Shop GS ?x? 8-Color Border
-- $f8 / $c323: Print Shop GS 88x52 8-color Clip Art
-- $f8 / $c324: Print Shop GS "Full Panel GC"
-- $f8 / $c325: Print Shop GS "Full Panel LH"
-- $f8 / $c328: Print Shop GS "Editor"
-- $f8 / $c329: Print Shop GS "Full Panel EV"
+ - BIN / $4800/5800/6800/7800, length 572 or 576: Print Shop 88x52 Monochrome Clip Art
+ - BIN / $4800/5800/6800/7800, length 144 or 148: Print Shop 12x12 Monochrome Border
+ - $f8 / $c311: Print Shop GS ?x? Monochrome Pattern
+ - $f8 / $c312: Print Shop GS ?x? Monochrome Border
+ - $f8 / $c313: Print Shop GS 88x52 Monochrome Clip Art
+ - $f8 / $c316: Print Shop GS Font
+ - $f8 / $c321: Print Shop GS ?x? 8-Color Pattern
+ - $f8 / $c322: Print Shop GS ?x? 8-Color Border
+ - $f8 / $c323: Print Shop GS 88x52 8-color Clip Art
+ - $f8 / $c324: Print Shop GS "Full Panel GC"
+ - $f8 / $c325: Print Shop GS "Full Panel LH"
+ - $f8 / $c328: Print Shop GS "Editor"
+ - $f8 / $c329: Print Shop GS "Full Panel EV"
 
 Primary references:
-
-- Reverse engineering
+ - Reverse engineering
 
 The ProDOS files used a generic type, so no file type notes exist for these formats.
 
 The web site https://theprintshop.club/ provides an emulated version of the original Apple II
 program that can print to PDF.
 
-## Clip Art
+## Clip Art ##
 
 The original Print Shop uses 88x52 monochrome images.  When printed or displayed, these are
 doubled in width and tripled in height to form a 176x156 image.  Print Shop GS also supports
@@ -42,42 +39,57 @@ the cyan plane.
 The actual color palette, as determined by a screen grab from an emulator, is comprised of RGB
 primaries and purple/orange that are similar to the classic Apple II hi-res colors.
 
-| Y M C | color  | red, green, blue |
-| ----- | ------ | ---------------- |
-| 0 0 0 | white  | 0xff, 0xff, 0xff |
-| 0 0 1 | blue   | 0x00, 0x00, 0xff |
-| 0 1 0 | red    | 0xff, 0x00, 0x00 |
-| 0 1 1 | purple | 0xcc, 0x00, 0xcc |
-| 1 0 0 | yellow | 0xff, 0xff, 0x00 |
-| 1 0 1 | green  | 0x00, 0xff, 0x00 |
-| 1 1 0 | orange | 0xff, 0x66, 0x00 |
-| 1 1 1 | black  | 0x00, 0x00, 0x00 |
+Y M C | color  | red, green, blue
+----- | ------ | ----------------
+0 0 0 | white  | 0xff, 0xff, 0xff
+0 0 1 | blue   | 0x00, 0x00, 0xff
+0 1 0 | red    | 0xff, 0x00, 0x00
+0 1 1 | purple | 0xcc, 0x00, 0xcc
+1 0 0 | yellow | 0xff, 0xff, 0x00
+1 0 1 | green  | 0x00, 0xff, 0x00
+1 1 0 | orange | 0xff, 0x66, 0x00
+1 1 1 | black  | 0x00, 0x00, 0x00
 
-## Fonts
+
+## Fonts ##
 
 Each font contains 59 characters (0-58).
 
-In the Print SHop Companion (PSC) font editor, offsets 0 (space) and 32 (image) are not editable.
+In the Print Shop Companion (PSC) font editor, offsets 0 (space) and 32 (image) are not editable.
 
-In Print Shop[, offset 32 points to the current graphic selected, which
-is generally not contained in the font file itself.  However, since it is an arbitrary data pointer, it is
-conceivble that there could be self-contained data in the file.
+In Print Shop, offset 32 points to the current graphic selected, which is not contained in the font
+file itself.
 
 The Space character is at offset 0, and in all the examples I've seen, has a height of 0 pixels.
-The data is calculated in the PSC font editor based off of an average of all other character widths.
+The data is calculated in the PSC font editor based off of an average of all other character
+widths.
 
-$5FF4-$5FFF - Optional Print Shop Companion Font Header (From Font Editor)
-$6000-$603A - Character widths (in pixels).  High bit indicates "Edited" in PSC.  Should be stripped.
-$603B-$6075 - Character heights in rows.
-$6076-$60B0 - Low Bytes of character data pointers
-$60B1-$60EB - High Bytes of character data pointers
-$60EC-EOF   - Character data.
+Character data is stored one bit per pixel, where 0 indicated background and 1 is foreground.  LSB
+is first.  Pixel data bytes are encoded left to right, as a series of rows.  Character data is
+arbitrarily located within the file but is accessible through ordered pointers as defined below.
 
-To check for validity, we can iterate through all 59 characters (excepting 0 and 32) and check that:
+The file format is:
+```
++$00/12:  ($5FF4) - Optional Print Shop Companion Font Header (From Font Editor)
++$0C/59:  ($6000) - Character widths (in pixels). High bit indicates "Edited" in PSC. Should be stripped.
++$3B/59:  ($603B) - Character heights in rows.
++$47/59:  ($6076) - Low Bytes of character data pointers
++$82/59:  ($60B1) - High Bytes of character data pointers
++$BD/nn:  ($60EC) - Character data.
+```
+If a 12-byte Print Shop Companion Header exists, the file is loaded at an earlier location in memory
+such that the Character Widths block always falls at $6000.  Pointers to font data are calculated
+with offset assumed. The presence or absence of the 12-byte header must be accounted for when
+dereferencing the internal pointers.
+
+To check for validity, we can iterate through all 59 characters (excluding 0 and 32) and check that:
 
 - The address pointers fall within the range of the data file.
-- Width and height values are "reasonable".  The PSC font editor limits character sizes to a max of 48x38 (152 bytes)
+- Width and height values are "reasonable".  The PSC font editor limits character sizes to a max of
+  48x38 (152 bytes)
 
-If all are within range, then acceptability should be flagged as Yes, if the pointers are in range, but some characters are out of the expected sizes, then the accptability should be flagged as ProbablyYes
+If all are within range, then acceptability should be flagged as Yes, if the pointers are in range,
+but some characters are out of the expected sizes, then the acceptability should be flagged as
+ProbablyYes
 
 Like the Print Shop graphic data, fonts are expanded 2x3 in usage.

--- a/FileConv/Gfx/PrintShopFont.cs
+++ b/FileConv/Gfx/PrintShopFont.cs
@@ -1,0 +1,416 @@
+﻿/*
+ * Copyright 2023 faddenSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Diagnostics;
+
+using CommonUtil;
+using DiskArc;
+
+namespace FileConv.Gfx
+{
+    /// <summary>
+    /// Converts Print Shop clip art of various types.
+    /// </summary>
+    public class PrintShopFont : Converter
+    {
+        public const string TAG = "psfont";
+        public const string LABEL = "Print Shop Font";
+        public const string DESCRIPTION =
+            "Converts a Print Shop or Print Shop font file to a bitmap.  " +
+            "These can optionally be pixel-multiplied x2/x3.";
+
+        // TODO
+        public const string DISCRIMINATOR =
+            "DOS B " +
+            ".";
+        public override string Tag => TAG;
+        public override string Label => LABEL;
+        public override string Description => DESCRIPTION;
+        public override string Discriminator => DISCRIMINATOR;
+
+        public const string OPT_MULT = "mult";
+
+        public override List<OptionDefinition> OptionDefs { get; protected set; } =
+            new List<OptionDefinition>() {
+                new OptionDefinition(OPT_MULT, "Multiply width/height",
+                    OptionDefinition.OptType.Boolean, "true"),
+            };
+
+        private const int MINIMUM_HEADER_SIZE = 576;
+        private const int PSC_FONT_HEADERS_SIZE = 12;
+        private const int MAX_CHARACTER_DATA_SIZE = 152;
+        private const int CLASSIC_MONO_LEN = 576;
+
+        // There are 59 characters in the font, but characters 0 and 32 are not standard. 
+        // This is taken into conderation when calculating MAX_FONT_FILE_SIZE.
+        private const int CHARACTER_COUNT = 59;
+        private const int MAX_FONT_FILE_SIZE = PSC_FONT_HEADERS_SIZE +
+                                               MINIMUM_HEADER_SIZE +
+                                               ((CHARACTER_COUNT - 2) * MAX_CHARACTER_DATA_SIZE) +
+                                               CLASSIC_MONO_LEN;
+
+        private const ushort FONT_WIDTH_TABLE = 0x6000;
+        private const ushort FONT_HEIGHT_TABLE = 0x603B;
+        private const ushort FONT_ADD_LO_TABLE = 0x6076;
+        private const ushort FONT_ADD_HI_TABLE = 0x60B1;
+        private const byte MAX_CHARACTER_HEIGHT = 38;
+        private const byte MAX_CHARACTER_WIDTH = 48;
+        private const ushort IMAGE_CHARACTER = 32;
+        const int INTER_CHARACTER_SPACING_PX = 3;
+
+        private const int XMULT = 2;
+        private const int YMULT = 3;
+
+
+        // We have to unpack the data in order to validate it, so might as well keep a copy of it for later.
+        private byte[]? DataBuf;
+
+        private PrintShopFont() { }
+
+        public PrintShopFont(FileAttribs attrs, Stream? dataStream, Stream? rsrcStream,
+                ResourceMgr? resMgr, ConvFlags convFlags, AppHook appHook)
+                : base(attrs, dataStream, rsrcStream, resMgr, convFlags, appHook)
+        {
+            Applic = TestApplicability();
+        }
+
+        protected override Applicability TestApplicability()
+        {
+            if (DataStream == null)
+            {
+                return Applicability.Not;
+            }
+
+            if (FileAttrs.FileType == FileAttribs.FILE_TYPE_BIN)
+            {
+                if (FileAttrs.DataLength <= MAX_FONT_FILE_SIZE &&
+                   ((FileAttrs.AuxType == 0x6000 && FileAttrs.DataLength >= MINIMUM_HEADER_SIZE) ||
+                    (FileAttrs.AuxType == 0x5FF4 && FileAttrs.DataLength >= MINIMUM_HEADER_SIZE + PSC_FONT_HEADERS_SIZE)))
+                {
+                    UnpackData();
+
+                    if (DataPointersAreValid())
+                    {
+                        if (CountOversizedCharacters() == 0)
+                        {
+                            return Applicability.Yes;
+                        }
+                        else
+                        {
+                            return Applicability.Probably;
+                        }
+                    }
+                }
+            }
+            return Applicability.Not;
+        }
+
+        public override Type GetExpectedType(Dictionary<string, string> options)
+        {
+            return typeof(IBitmap);
+        }
+
+        public override IConvOutput ConvertFile(Dictionary<string, string> options)
+        {
+            if (Applic <= Applicability.Not)
+            {
+                Debug.Assert(false);
+                return new ErrorText("ERROR");
+            }
+
+            Debug.Assert(DataBuf != null);
+            Debug.Assert(DataBuf.Length >= 0);
+            Debug.Assert(DataStream != null);
+
+
+            bool doMult = GetBoolOption(options, OPT_MULT, false);
+
+            return ConvertMono(DataBuf, Palette8.Palette_MonoBW, doMult);
+        }
+
+        /// <summary>
+        /// Converts a Print Shop font file to a B&amp;W bitmap.
+        /// </summary>
+        public Bitmap8 ConvertMono(byte[] buf, Palette8 palette, bool doMult)
+        {
+            Bitmap8 output;
+
+            int totalWidth = 0;
+            int maxHeight = 0;
+
+            for (int idx = 1; idx < CHARACTER_COUNT; idx++)
+            {
+                if (idx != 32)
+                {
+                    if (idx != 1) totalWidth += INTER_CHARACTER_SPACING_PX;
+                    totalWidth += GetWidthForCharacter(idx);
+                    int height = GetHeightForCharacter(idx);
+                    if (height > maxHeight) { maxHeight = height; }
+                }
+            }
+
+            Debug.WriteLine("TotalWidth: " + totalWidth);
+
+            if (doMult)
+            {
+                output = new Bitmap8((4 + totalWidth) * XMULT, (4 + maxHeight) * YMULT);
+                Debug.WriteLine("Bitmap3: Width: " + (4 + totalWidth) * XMULT + " Height: " + (4 + maxHeight) * YMULT);
+            }
+            else
+            {
+                output = new Bitmap8(totalWidth + 4, maxHeight + 4);
+                Debug.WriteLine("Bitmap: Width: " + totalWidth + 4 + " Height: " + maxHeight + 4);
+            }
+            output.SetPalette(palette);
+
+            int xOffset = 1;
+            for (int idx = 1; idx < CHARACTER_COUNT; idx++)
+            {
+                if (idx != 32)
+                {
+                    byte charWidth = GetWidthForCharacter(idx);
+                    byte charHeight = GetHeightForCharacter(idx);
+                    byte[] charData = GetDataForCharacter(idx);
+
+                    int offset = 0;
+                    for (int row = 0; row < charHeight; row++)
+                    {
+                        for (int col = 0; col < WidthToBytes(charWidth); col++)
+                        {
+
+                            byte bval = charData[offset++];
+                            for (int bit = 0; bit < 8; bit++)
+                            {
+                                // Bits are zero for white, one for black; leftmost pixel in MSB.
+                                byte color = (byte)(bval >> 7);
+
+                                if (col * 8 + bit + xOffset < totalWidth)
+                                {
+                                    if (doMult)
+                                    {
+                                        SetMultPixels(output, col * 8 + bit + xOffset, row + 1, color);
+                                    }
+                                    else
+                                    {
+                                        output.SetPixelIndex(col * 8 + bit + xOffset, row + 1, color);
+                                    }
+                                }
+                                bval <<= 1;
+                            }
+                        }
+                    }
+                    xOffset += charWidth + INTER_CHARACTER_SPACING_PX;
+
+                }
+            }
+            return output;
+        }
+
+        /// <summary>
+        /// Sets a rectangular block of pixels to the same value, as part of pixel-multiplying
+        /// an image.
+        /// </summary>
+        /// <param name="output">Bitmap to draw to.</param>
+        /// <param name="col">Column number (pre-multiplied value).</param>
+        /// <param name="row">Row number (pre-multiplied value).</param>
+        /// <param name="colorIndex">Color index.</param>
+        private static void SetMultPixels(Bitmap8 output, int col, int row, byte colorIndex)
+        {
+            for (int y = 0; y < YMULT; y++)
+            {
+                for (int x = 0; x < XMULT; x++)
+                {
+                    output.SetPixelIndex(col * XMULT + x, row * YMULT + y, colorIndex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the height in pixels for the character at the  given offset.
+        /// </summary>
+        /// <param name="offset">The character height to fetch</param>
+        /// <returns>The pixel height of the character within the file.</returns>
+        private byte GetHeightForCharacter(int offset)
+        {
+            Debug.Assert(DataBuf != null);
+            Debug.Assert(offset >= 0 && offset < CHARACTER_COUNT);
+
+            ushort heights = (ushort)(FONT_HEIGHT_TABLE - FileAttrs.AuxType);
+            byte height = DataBuf[offset + heights];
+            return height;
+        }
+
+        /// <summary>
+        /// Get the width in pixels for the character at the  given offset.
+        /// </summary>
+        /// <param name="offset">The character width to fetch</param>
+        /// <returns>The pixel width of the character within the file.</returns>
+        private byte GetWidthForCharacter(int offset)
+        {
+            Debug.Assert(DataBuf != null);
+            Debug.Assert(offset >= 0 && offset < CHARACTER_COUNT);
+
+            ushort widths = (ushort)(FONT_WIDTH_TABLE - FileAttrs.AuxType);
+            byte width = (byte)(DataBuf[offset + widths] & 0x7f);
+            return width;
+        }
+
+        /// <summary>
+        /// Get the data block pointer for the character at the  given offset.
+        /// </summary>
+        /// <param name="offset">The character offset to fetch</param>
+        /// <returns>The pointer to the data within the file.</returns>
+        private ushort GetAddressForCharacter(int offset)
+        {
+            Debug.Assert(DataBuf != null);
+            Debug.Assert(offset >= 0 && offset < CHARACTER_COUNT);
+
+            ushort loVals = (ushort)(FONT_ADD_LO_TABLE - FileAttrs.AuxType);
+            ushort hiVals = (ushort)(FONT_ADD_HI_TABLE - FileAttrs.AuxType);
+            ushort addr = (ushort)(DataBuf[offset + loVals] + 256 * DataBuf[offset + hiVals]);
+            return addr;
+        }
+
+        /// <summary>
+        /// Get the data block from the file at the pointer for the character at the given offset.
+        /// </summary>
+        /// <param name="offset">The character offset to fetch.</param>
+        /// <returns>A byte array containing the character data.</returns>
+        private byte[] GetDataForCharacter(int offset)
+        {
+            Debug.Assert(DataBuf != null);
+            Debug.Assert(offset >= 0 && offset < CHARACTER_COUNT);
+            byte width = GetWidthForCharacter(offset);
+
+            int dataLength = GetHeightForCharacter(offset) * WidthToBytes(width);
+
+            ushort dataOffset = (ushort)(GetAddressForCharacter(offset) - FileAttrs.AuxType);
+
+            byte[] retval = new byte[dataLength];
+            for (int idx = 0; idx < dataLength; idx++)
+            {
+                retval[idx] = DataBuf[dataOffset + idx];
+            }
+            return retval;
+        }
+
+        /// <summary>
+        /// Calculates the number of bytes it takes to store a given run of pixels.
+        /// </summary>
+        /// <param name="width">The number of pixels to use.</param>
+        /// <returns>The number of bytes it takes to pack the given pixel count.</returns>
+        private static byte WidthToBytes(byte width)
+        {
+            if (width == 0) return 0;
+            return (byte)(((width - 1) / 8) + 1);
+        }
+
+        /// <summary>
+        ///  Reads the data from the datastream into a byte array.  
+        /// </summary>
+        private void UnpackData()
+        {
+            Debug.Assert(DataStream != null);
+
+            DataBuf = new byte[DataStream.Length];
+            DataStream.Position = 0;
+            DataStream.ReadExactly(DataBuf, 0, DataBuf.Length);
+        }
+
+        /// <summary>
+        /// Checks to see if the data offsets of each character in the file point to an internal data block within the file. 
+        /// </summary>
+        /// <returns>True, if the offsets are contained within the font file, False otherwise.</returns>
+        private bool DataPointersAreValid()
+        {
+            Debug.Assert(DataBuf != null);
+            Debug.Assert(DataBuf.Length > MINIMUM_HEADER_SIZE + PSC_FONT_HEADERS_SIZE);
+
+            bool valid = true;
+
+            for (byte idx = 1; idx < CHARACTER_COUNT && valid; idx++)
+            {
+                if (idx != IMAGE_CHARACTER)
+                {  // We don't want to check the "Image" character @ offset 32.
+                    ushort addr = GetAddressForCharacter(idx);
+
+                    if (!(addr >= 0x6000 && addr < FileAttrs.AuxType + DataBuf.Length))
+                    {
+                        Debug.WriteLine("Address out of range for Character " + idx);
+                    }
+
+                    valid &= addr >= 0x6000 && addr < FileAttrs.AuxType + DataBuf.Length;
+                }
+            }
+
+            if (!valid)
+            {
+                Debug.WriteLine("Valid is not set for this font.");
+            }
+
+            return valid;
+        }
+
+
+        /// <summary>
+        /// Checks to see if the widths and heights of each character in the file are 
+        /// consistent with those of a Print Shop font file. 
+        /// </summary>
+        /// <returns>Count of the total characters that are larger than those that can be edited 
+        /// in the Print Shop Companion font editor.</returns>
+        private int CountOversizedCharacters()
+        {
+            Debug.Assert(DataBuf != null);
+            Debug.Assert(DataBuf.Length > MINIMUM_HEADER_SIZE + PSC_FONT_HEADERS_SIZE);
+
+            int oversized = 0;
+
+            for (ushort idx = 1; idx < CHARACTER_COUNT; idx++)
+            {
+                if (idx != IMAGE_CHARACTER)
+                {  // We don't want to check the "Image" character @ offset 32.
+                    byte width = GetWidthForCharacter(idx);
+                    byte height = GetHeightForCharacter(idx);
+
+                    if (!(height <= MAX_CHARACTER_HEIGHT))
+                    {
+                        Debug.WriteLine("Height out of range for Character " + idx);
+                    }
+
+                    if (!(width <= MAX_CHARACTER_WIDTH))
+                    {
+                        Debug.WriteLine("Width out of range for Character " + idx);
+                    }
+
+                    if (height <= MAX_CHARACTER_HEIGHT && width <= MAX_CHARACTER_WIDTH)
+                    {
+                        oversized++;
+                    }
+                }
+            }
+
+            if (oversized > 0)
+            {
+                Debug.WriteLine(oversized + " character(s) are oversized}.");
+            }
+
+            return oversized;
+        }
+    }
+
+}
+
+

--- a/FileConv/Gfx/PrintShopFont.cs
+++ b/FileConv/Gfx/PrintShopFont.cs
@@ -22,7 +22,7 @@ using DiskArc;
 namespace FileConv.Gfx
 {
     /// <summary>
-    /// Converts Print Shop clip art of various types.
+    /// Converts Print Shop fonts.
     /// </summary>
     public class PrintShopFont : Converter
     {


### PR DESCRIPTION
This is a Converter subclass to process Print Shop fonts.  It is based off of the PrintShopClip class.  It does make-or-break validation on the 2 potential starting addresses, the maximum-allowed file length, and the integrity of the internal character pointers within the file.  It also does secondary validation on the widths and heights of each character in the file to check for conformation to the boundaries available in the Print Shop Companion font editor (49x39).  If the geometry isn't 100% conforming, the validator still passes with a ProbablyYes status.  I have tested it on the fonts on a modified-for-readability Print Shop disk, the Print Shop Companion disk, and various 3rd-party font library disks.  There is currently only DOS B-Type file support, and no support for ProDOS and Print Shop GS fonts, which I plan on implementing as I get more data to research and test with. 

One quirk of the Print Shop fonts is that the character at offset #32 is used as a pointer to the clip art image the user selects in the program to use in the current project.  While it is possible to include self-contained data for that character within the font file, it doesn't seem to be a common occurrence, and it would be ignored by the Print Shop application, so my code just skips that character altogether. 

Also included are documentation updates in the PrintShop-notes.md file, sharing my research notes from my exploration of the font format and thoughts I had while implementing this class.