### PR TITLE
correct length of version/min-version field of Directory header

### DIFF
--- a/DiskArc/FS/ProDOS-notes.md
+++ b/DiskArc/FS/ProDOS-notes.md
@@ -105,7 +105,7 @@ Directory header:
 +$10 / 1: (reserved, must contain $75 for P8, or $76 for GS/OS)
 +$11 / 7: (reserved, should be zeroes)
 +$18 / 4: creation date/time of this directory (redundant, not updated)
-+$1c / 4: version/min-version (not used for lower-case flags)
++$1c / 2: version/min-version (not used for lower-case flags)
 +$1e / 1: access flags (redundant, not updated)
 +$1f / 1: directory entry length (usually $27)
 +$20 / 1: entries per directory block (usually $200/$27 = $0d)
@@ -124,7 +124,7 @@ Regular directory entry:
 +$13 / 2: blocks used
 +$15 / 3: EOF
 +$18 / 4: creation date/time
-+$1c / 4: version/min-version -OR- lower-case flags (see TN.GSOS.008)
++$1c / 2: version/min-version -OR- lower-case flags (see TN.GSOS.008)
 +$1e / 1: access flags
 +$1f / 2: aux type
 +$21 / 4: modification date/time

--- a/docs/formatdoc/ProDOS-notes.html
+++ b/docs/formatdoc/ProDOS-notes.html
@@ -109,7 +109,7 @@ from that in subdirectories.</p>
 +$10 / 1: (reserved, must contain $75 for P8, or $76 for GS/OS)
 +$11 / 7: (reserved, should be zeroes)
 +$18 / 4: creation date/time of this directory (redundant, not updated)
-+$1c / 4: version/min-version (not used for lower-case flags)
++$1c / 2: version/min-version (not used for lower-case flags)
 +$1e / 1: access flags (redundant, not updated)
 +$1f / 1: directory entry length (usually $27)
 +$20 / 1: entries per directory block (usually $200/$27 = $0d)

--- a/docs/formatdoc/ProDOS-notes.html
+++ b/docs/formatdoc/ProDOS-notes.html
@@ -126,7 +126,7 @@ from that in subdirectories.</p>
 +$13 / 2: blocks used
 +$15 / 3: EOF
 +$18 / 4: creation date/time
-+$1c / 4: version/min-version -OR- lower-case flags (see TN.GSOS.008)
++$1c / 2: version/min-version -OR- lower-case flags (see TN.GSOS.008)
 +$1e / 1: access flags
 +$1f / 2: aux type
 +$21 / 4: modification date/time


### PR DESCRIPTION
These two fields are 1 byte each, totalling 2 bytes. Elsewhere in the docs this is correct but in this one spot it was wrongly documented to be 4 bytes.