### PR TITLE
Fix filename offset in MacBinary-notes.md

### DIFF
--- a/DiskArc/Arc/MacBinary-notes.md
+++ b/DiskArc/Arc/MacBinary-notes.md
@@ -49,7 +49,7 @@ some implementations left garbage in the unused fields.)
 The file header is:
 ```
 +$00 / 1: version byte, must be zero
-+$02 /64: filename, with leading length byte
++$01 /64: filename, with leading length byte
 +$41 /16: Finder FInfo block (originated in MFS)
   +$00 / 4: fdType - file type
   +$04 / 4: fdCreator - creator


### PR DESCRIPTION
The length byte (1-63) is at offset 1. That many bytes of filename begin at offset 2.