### PR TITLE
Make mkcp2.sh more portable

### DIFF
--- a/mkcp2.sh
+++ b/mkcp2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This builds the CiderPress II command-line utility ("cp2").  You must
 # have the .NET development tools installed (this uses the "dotnet build"


### PR DESCRIPTION
Very minor but not all systems have bash at /bin/bash - usually considered more portable to use /usr/bin/env to find the shell.

Also I've packaged ciderpress2 for Nix/NixOS - https://github.com/NixOS/nixpkgs/pull/436246