### PR TITLE
Updated to .NET 8

### DIFF
--- a/AppCommon/AppCommon.csproj
+++ b/AppCommon/AppCommon.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/CommonUtil/CommonUtil.csproj
+++ b/CommonUtil/CommonUtil.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DiskArc/DiskArc.csproj
+++ b/DiskArc/DiskArc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DiskArcTests/DiskArcTests.csproj
+++ b/DiskArcTests/DiskArcTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Examples/AddFile/AddFile.csproj
+++ b/Examples/AddFile/AddFile.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Examples/ListContents/ListContents.csproj
+++ b/Examples/ListContents/ListContents.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/FileConv/FileConv.csproj
+++ b/FileConv/FileConv.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/FileConvTests/FileConvTests.csproj
+++ b/FileConvTests/FileConvTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Install.md
+++ b/Install.md
@@ -1,20 +1,18 @@
 # CiderPress II Download and Installation Guide #
 
-The command-line and GUI applications are written in C#, targeted to .NET Core 6.  The .NET
+The command-line and GUI applications are written in C#, targeted to .NET 8.  The .NET
 runtime is available for download from Microsoft for a variety of platforms, including Windows,
 Mac OS, and Linux.  It's even available for the
 [Raspberry PI](https://learn.microsoft.com/en-us/dotnet/iot/deployment).
-The [documentation](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md)
-says that .NET Core 6 is only supported for Windows 10+, MacOS 13+, and recent versions of Linux,
-but in practice the command-line tool has been used successfully on Windows 7 and MacOS 11 (these
-are officially "out of support").
+The [documentation](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md)
+says that .NET 8 is only supported for Windows 10+, MacOS 13+, and recent versions of Linux.
 
 While the command-line tool is usable on multiple platforms, the GUI is currently only available
 for Windows (native or emulated).
 
 There are two types of downloads here: self-contained and framework-dependent.  The former
 includes all necessary parts of the .NET runtime in the package, so there's no need to have .NET
-installed on your system.  If you happen to have .NET Core 6 or later already installed, the
+installed on your system.  If you happen to have .NET 8 or later already installed, the
 framework-dependent package is significantly smaller.  You can also download a pre-packaged Wine
 binary that allows you to run the GUI application on recent versions of Mac OS, but this may have
 stability issues and is considered experimental.
@@ -109,7 +107,7 @@ systems are expected to work.  Older versions of the operating systems may or ma
 example, the CLI application has been successfully run on Windows 7 32-bit (x86), but this will
 not be tested regularly.
 
-The code is targeted to .NET Core 6, and is expected to work on newer versions of the runtime.
+The code is targeted to .NET 8, and is expected to work on newer versions of the runtime.
 
 ## Support for Other Systems ##
 

--- a/MakeDist/MakeDist.csproj
+++ b/MakeDist/MakeDist.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ as copy and replace whole disk partitions.
 For installation instructions, see the [install guide](Install.md).
 
 **Current status:**
- - The command-line tool runs on Windows, macOS, and Linux (anywhere .NET Core 6 runs).
+ - The command-line tool runs on Windows, macOS, and Linux (anywhere .NET 8 runs).
  - The desktop GUI is written for Windows, but [can be made to run](WineNotes.md) on other
    systems with Wine emulation.
  - Brief (3 min) video introduction to v1.0: https://youtu.be/ZrUfNzscq3g

--- a/SourceNotes.md
+++ b/SourceNotes.md
@@ -2,7 +2,7 @@
 
 All of the code is written in C# .NET, using the (free to download) Visual
 Studio Community 2022 IDE as the primary development environment.  All of
-the code targets .NET Core 6.  With the exception of the WPF application,
+the code targets .NET 8.  With the exception of the WPF application,
 none of the code has a machine-specific target.  The projects can be built
 for a 32-bit or 64-bit environment.
 

--- a/cp2/cp2.csproj
+++ b/cp2/cp2.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <StartupObject>cp2.CP2Main</StartupObject>

--- a/cp2_wpf/cp2_wpf.csproj
+++ b/cp2_wpf/cp2_wpf.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+  <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <AssemblyName>CiderPress2</AssemblyName>

--- a/ndocs/top/Install.md
+++ b/ndocs/top/Install.md
@@ -1,11 +1,11 @@
 # CiderPress II Download and Installation Guide #
 
-The command-line and GUI applications are written in C#, targeted to .NET Core 6.  The .NET
+The command-line and GUI applications are written in C#, targeted to .NET 8.  The .NET
 runtime is available for download from Microsoft for a variety of platforms, including Windows,
 Mac OS, and Linux.  It's even available for the
 [Raspberry PI](https://learn.microsoft.com/en-us/dotnet/iot/deployment).
-The [documentation](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md)
-says that .NET Core 6 is only supported for Windows 10+, MacOS 13+, and recent versions of Linux,
+The [documentation](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md)
+says that .NET 8 is only supported for Windows 10+, MacOS 13+, and recent versions of Linux,
 but in practice the command-line tool has been used successfully on Windows 7 and MacOS 11 (these
 are officially "out of support").
 
@@ -14,7 +14,7 @@ for Windows (native or emulated).
 
 There are two types of downloads here: self-contained and framework-dependent.  The former
 includes all necessary parts of the .NET runtime in the package, so there's no need to have .NET
-installed on your system.  If you happen to have .NET Core 6 or later already installed, the
+installed on your system.  If you happen to have .NET 8 or later already installed, the
 framework-dependent package is significantly smaller.  You can also download a pre-packaged Wine
 binary that allows you to run the GUI application on recent versions of Mac OS, but this may have
 stability issues and is considered experimental.
@@ -109,7 +109,7 @@ systems are expected to work.  Older versions of the operating systems may or ma
 example, the CLI application has been successfully run on Windows 7 32-bit (x86), but this will
 not be tested regularly.
 
-The code is targeted to .NET Core 6, and is expected to work on newer versions of the runtime.
+The code is targeted to .NET 8, and is expected to work on newer versions of the runtime.
 
 ## Support for Other Systems ##
 

--- a/ndocs/top/README.md
+++ b/ndocs/top/README.md
@@ -13,7 +13,7 @@ as copy and replace whole disk partitions.
 For installation instructions, see the [install guide](Install.md).
 
 **Current status:**
- - The command-line tool runs on Windows, macOS, and Linux (anywhere .NET Core 6 runs).
+ - The command-line tool runs on Windows, macOS, and Linux (anywhere .NET 8 runs).
  - The desktop GUI is written for Windows, but [can be made to run](WineNotes.md) on other
    systems with Wine emulation.
  - Brief (3 min) video introduction to v1.0: https://youtu.be/ZrUfNzscq3g

--- a/ndocs/top/SourceNotes.md
+++ b/ndocs/top/SourceNotes.md
@@ -2,7 +2,7 @@
 
 All of the code is written in C# .NET, using the (free to download) Visual
 Studio Community 2022 IDE as the primary development environment.  All of
-the code targets .NET Core 6.  With the exception of the WPF application,
+the code targets .NET 8.  With the exception of the WPF application,
 none of the code has a machine-specific target.  The projects can be built
 for a 32-bit or 64-bit environment.
 


### PR DESCRIPTION
These are the changes to build the code under .NET 8.  I haven't tested the Windows-specific code, but the command line stuff seems to work fine under Linux.  I also updated the docs to refer to 8.0. I was iffy on the code that mentions Win 7, etc.. I left it in place in the ndocs Install.md but changed it in the root directory's version.